### PR TITLE
Update node identifier for let (to be "l")

### DIFF
--- a/ir/README.md
+++ b/ir/README.md
@@ -27,7 +27,7 @@ The only requirement on label string is that they are nonempty and contain no wh
 // apply(function, argument)
 {"0": "a", "f": expression, "a": expression}
 // let(label, value, then)
-{"0": "a", "l": label, "v": expression, "t": expression}
+{"0": "l", "l": label, "v": expression, "t": expression}
 // b already taken when adding binary
 // binary(value)
 {"0": "x", "v": bytes}


### PR DESCRIPTION
I think there's a discrepancy between the IR and the reference implementation (JS version) .