### PR TITLE
fix punctuation in "Embedding in Gleam" guide

### DIFF
--- a/guides/embedding_in_gleam.md
+++ b/guides/embedding_in_gleam.md
@@ -224,8 +224,8 @@ The runners so far have all returned a result to handle the case of the program 
 
 EYG implements sound structural type inference including inference of all effect types.
 
-Running this type checker is optional
-For a script that is intended to run and finish type checking before running the script doesn't add much.
+Running this type checker is optional.
+For a script that is intended to run and finish, type checking before running the script doesn't add much.
 In most other circumstances asserting that the EYG program has no runtime errors is invaluable.
 
 ```gleam


### PR DESCRIPTION
Hello! Just wanted to add a bit of punctuation to help make the sentences more clear. As I was reading this section, it took me a second to figure out what it was saying since I read these parts as

- "Running this type checker is optional for a script..." (I assumed the capital letter was a typo)
- "...intended to run and finish type checking..."

No worries if you don't think these changes are applicable, though. This looks like a really interesting project, thanks for sharing it!